### PR TITLE
fix(yandex): fix error with deeply nested objects

### DIFF
--- a/lib/service/yandex.js
+++ b/lib/service/yandex.js
@@ -16,6 +16,11 @@ function translateString(language, key, destObj) {
 
 	return new Promise(function (resolve, reject) {
 		var valuesStr = valuesArray.join(hashSimple);
+		if (valuesStr === ''){
+			// there is nothing to translate, so don't ask Yandex (Yandex will respond with an error)
+			resolve(destObj);
+			return;
+		}
 		translateService.translate(valuesStr, {to: language}, function (err, res) {
 			if (err || !res) {
 				reject('Yandex translation service failed', err);

--- a/lib/service/yandex.js
+++ b/lib/service/yandex.js
@@ -16,7 +16,7 @@ function translateString(language, key, destObj) {
 
 	return new Promise(function (resolve, reject) {
 		var valuesStr = valuesArray.join(hashSimple);
-		if (valuesStr === ''){
+		if (valuesStr === '') {
 			// there is nothing to translate, so don't ask Yandex (Yandex will respond with an error)
 			resolve(destObj);
 			return;


### PR DESCRIPTION
(e.g. objects which only contain objects, and no strings)