### PR TITLE
Issue 14: fix(yandex api): change hashSimple for split\join an array

### DIFF
--- a/lib/service/yandex.js
+++ b/lib/service/yandex.js
@@ -1,7 +1,7 @@
 var Promise = require('promise');
 var _ = require('lodash');
 
-var hashSimple = '[(.|.)]';
+var hashSimple = '/|/|/|';
 var translateService;
 
 function init(setting) {


### PR DESCRIPTION
Issue https://github.com/KhaledMohamedP/translate-json-object/issues/14

### Solution
Yandex API not correctly translate with `[(.|.)]` sybmols
We change it to `/|/|/|`