### PR TITLE
Fixed issue with parsing yandex values containing '/' character

### DIFF
--- a/lib/service/yandex.js
+++ b/lib/service/yandex.js
@@ -1,7 +1,7 @@
 var Promise = require('promise');
 var _ = require('lodash');
 
-var hashSimple = '/|/|/|';
+var hashSimple = '@@@';
 var translateService;
 
 function init(setting) {


### PR DESCRIPTION
Value of hashSimple used for joining and splitting array was changed from '/|/|/|' to '@@@'.
This was because yandex sometimes returns '/' in response text. This caused issues when converting result back to array.