### PR TITLE
fix($yandex): Fixed issue with parsing yandex values containing '/' c…

### DIFF
--- a/lib/service/yandex.js
+++ b/lib/service/yandex.js
@@ -1,7 +1,7 @@
 var Promise = require('promise');
 var _ = require('lodash');
 
-var hashSimple = '/|/|/|';
+var hashSimple = '@@@';
 var translateService;
 
 function init(setting) {


### PR DESCRIPTION
 Yandex output sometimes contained '/' character (eg. to denote alternative translations). This
caused issues because this character was also used as text separator (hash). Changing separator
to '@@@' resolves problems.

Fixes #22