### PR TITLE
Update lodash to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "google-translate": "2.2.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.20",
     "promise": "8.0.3",
     "yandex-translate": "2.1.3"
   },


### PR DESCRIPTION
There is an open security warning on lodash <= 4.17.19.. https://www.npmjs.com/advisories/1523